### PR TITLE
Display account name instead UniqueId on home page

### DIFF
--- a/src/Web/BankSystem.Web/Views/Home/Index.cshtml
+++ b/src/Web/BankSystem.Web/Views/Home/Index.cshtml
@@ -45,8 +45,8 @@
                     {
                         <div class="row">
                             @* TODO: Redirect to my accounts details when we implement it *@
-                            <p class="col-6 card-text"><a href="">@account.UniqueId</a></p>
-                            <p class="col-6 card-text text-green text-right">@account.Balance EUR</p>
+                            <p class="col-6 card-text"><a href="">@account.Name</a></p>
+                            <p class="col-6 card-text text-green text-right">€@account.Balance</p>
                         </div>
                     }
                     


### PR DESCRIPTION
Closes #24 