### PR TITLE
Fix client side form validation not working

### DIFF
--- a/src/Web/BankSystem.Web/bundleconfig.json
+++ b/src/Web/BankSystem.Web/bundleconfig.json
@@ -15,7 +15,7 @@
       "wwwroot/source/vendor/js/bootstrap.js",
       "wwwroot/source/vendor/js/moment.js",
       "wwwroot/source/vendor/js/jquery.validate.js",
-      "wwwroot/source/vendor/js/jquery.validate.unobtrusive.js.js"
+      "wwwroot/source/vendor/js/jquery.validate.unobtrusive.js"
     ],
     "minify": {
       "enabled": true


### PR DESCRIPTION
Fix typo in bundleconfig.json causing jquery.validate.unobtrusive.js not to be included in bundle
Fixes #45 